### PR TITLE
strip cLIMS upload csv

### DIFF
--- a/cLIMS/organization/importSeqFiles.py
+++ b/cLIMS/organization/importSeqFiles.py
@@ -10,7 +10,7 @@ def importSeqFiles(request,pk):
     template_name = 'importFiles.html'
     excel_file = request.FILES['excel_file']
     excel_file_content=excel_file.read().decode("utf-8")
-    lines = excel_file_content.split("\n")
+    lines = excel_file_content.rstrip().split("\n")
     runDict=OrderedDict()
     orderList=[]
     context = {}


### PR DESCRIPTION
this little change addresses the issue that a lot of people had uploading their clims-csv in the `ImportSequencing` wizard thing:
 - new line at the end of the file was giving a non-intepretable error message
 - and often even after removing the last line in the clims upload csv it was still hanging there - depending on OS and text editor in use

Here we are simply "sanitizing" input data before it gets split into several lines, i.e. `excel_file_content.rstrip()` and only then we'd do `.split('\n')` .
the default `.rstip()` should take care of both windows and osx, whatever newline symbols - we're guessing - is it the case ?!

this is tiny , but rather important change

 - Sergey and Snehal