### PR TITLE
Enabling cloning

### DIFF
--- a/cLIMS/organization/editViews.py
+++ b/cLIMS/organization/editViews.py
@@ -98,7 +98,6 @@ class EditExperiment(UpdateView):
         obj = Experiment.objects.get(pk=self.get_object().id)
         
         projectId=obj.project.id
-
         if(obj.experiment_fields):
             context['jsonObj']= json.loads(obj.experiment_fields)
         context['form'].fields["type"].queryset = JsonObjField.objects.filter(field_type="Experiment")
@@ -286,6 +285,7 @@ class EditBiosample(UpdateView):
             for f in formFields:
                 context['form'].fields[f].queryset = (context['form'].fields[f].queryset).filter(userOwner=self.request.user.pk)
         context['ProjectId']=self.kwargs['prj_pk']
+        context['caution']= True
         return context
 
         

--- a/cLIMS/organization/templates/customForm.html
+++ b/cLIMS/organization/templates/customForm.html
@@ -44,11 +44,11 @@ function makeReq() {
 			{{ form.non_field_errors }}
 			{% for field in form %}
 					  {% if form_class == "Experiment Clone" and 'Biosample name' in field.label %}
-						<p>CAUTION!!! Entering details below will create NEW Biosample.
+						<p style="color:red">CAUTION!!! Entering details below will create NEW Biosample.
 							If left blank, it will use the EXISTING Biosample of the experiment being cloned.
 						</p>
-						<p>Editing the Biosample after cloning will make the changes 
-							in all the experiments where this new/existing Biosample is used.
+						<p style="color:red">Editing the Biosample after cloning will make the changes 
+							in all the experiments wherever this new/existing Biosample is used.
 						</p>
 					  {% endif %}
 				<div class="fieldWrapper">

--- a/cLIMS/organization/templates/customForm.html
+++ b/cLIMS/organization/templates/customForm.html
@@ -39,10 +39,18 @@ function makeReq() {
 			{% endfor %}
 			<br/><br/><input type="radio" id="newForm" name="selectForm"  onclick="makeReq()" value="new" checked="checked">&nbsp;&nbsp;OR Fill a new one<br/><br/>
 		{% endif %}
-		
+	
 		 {% if form %}
 			{{ form.non_field_errors }}
 			{% for field in form %}
+					  {% if form_class == "Experiment Clone" and 'Biosample name' in field.label %}
+						<p>CAUTION!!! Entering details below will create NEW Biosample.
+							If left blank, it will use the EXISTING Biosample of the experiment being cloned.
+						</p>
+						<p>Editing the Biosample after cloning will make the changes 
+							in all the experiments where this new/existing Biosample is used.
+						</p>
+					  {% endif %}
 				<div class="fieldWrapper">
 					 {{field.errors}}
 					 <a style="cursor: pointer;"><i class="fa fa-question-circle" title="{{field.help_text}}"></i></a>

--- a/cLIMS/organization/templates/detailExperiment.html
+++ b/cLIMS/organization/templates/detailExperiment.html
@@ -268,12 +268,12 @@
 <a style="cursor: pointer;"><i class="fa fa-minus-square-o collapse hidden" aria-hidden="true"></i></a>
 <span class="tableHead">Associated Biosample Details</span><br/>
 <div class="divData hidden">
-<!--<a href="/deleteBiosample/{{ experiment.project.id }}/{{ biosample.id }}">
+<a href="/deleteBiosample/{{ experiment.project.id }}/{{ biosample.id }}">
 <button type="button" class="btn btn-danger pull-right hidden show">Delete</button>
 </a>
 <a href="/editBiosample/{{ experiment.project.id }}/{{ experiment.id }}/{{biosample.id}}">
 	<button type="button" class="btn btn-warning pull-right hidden show">Edit</button>
-</a>-->
+</a>
 <span class="rowHead">Biosample Name: </span>{{biosample.biosample_name}}<br/>
 <span class="rowHead">Biosample Biosource: </span>{{biosample.biosample_biosource}}<br/>
 <span class="rowHead">Biosample Individual: </span>{{ biosample.biosample_individual }}<br/>

--- a/cLIMS/organization/templates/editForm.html
+++ b/cLIMS/organization/templates/editForm.html
@@ -28,6 +28,13 @@ function makeReq() {
     {% endif %}
 	<form method="post" enctype="multipart/form-data">
 		{% csrf_token %}
+		{% if caution  %}
+						<p style="color:red"> 
+							CAUTION!!! Changing name will NOT create a new Biosample, existing Biosample will be renamed.
+							Making changes here will make changes in the all the Experiments 
+							where this biosample is used.
+						</p>
+		{% endif %}
 		<h1>{{form_class}}</h1>
 		{% if  isExisting %}
 		<input type="radio" id="oldForm" name="selectForm" onclick="makeReq()" value="old">&nbsp;&nbsp;Choose Existing One<br/><br/>


### PR DESCRIPTION
Removal of Edit/Delete options is causing inconvenience while entering new data.
Users would clone the experiments and then make changes, but after removing edits this was not feasible.
So here, only Biosample has been given access to edit/delete.
A caution note has been added to let users know about the consequences of editing biosample after cloning.
