### PR TITLE
Adding new references DT40 and T2T for distiller run

### DIFF
--- a/cLIMS/organization/templates/exportDistillerForm.html
+++ b/cLIMS/organization/templates/exportDistillerForm.html
@@ -31,6 +31,8 @@
   <option value="galGal5">galGal5</option>
   <option value="smic1.0">smic1.0</option>
   <option value="sacCer3">sacCer3</option>
+  <option value="DT40">DT40</option>
+  <option value="T2T">T2T</option>
 </select>
 <hr>
 <h5>**Only selected experiments will be exported.</h5>

--- a/cLIMS/tools/distillerTools/sample_genomes.yaml
+++ b/cLIMS/tools/distillerTools/sample_genomes.yaml
@@ -22,4 +22,10 @@ smic1.0:
 sacCer3:
   bwa_index_wildcard_path: '/nl/umw_job_dekker/cshare/reference/bwa/sacCer3/sacCer3.*'
   chrom_sizes_path: '/nl/umw_job_dekker/cshare/reference/sorted_chromsizes/sacCer3.reduced.chrom.sizes'
+DT40:
+  bwa_index_wildcard_path: '/nl/umw_job_dekker/cshare/reference/bwa/DT40/DT40.*'
+  chrom_sizes_path: '/nl/umw_job_dekker/cshare/reference/sorted_chromsizes/DT40.reduced.chrom.sizes'
+T2T:
+  bwa_index_wildcard_path: '/nl/umw_job_dekker/cshare/reference/bwa/T2T/T2T.*'
+  chrom_sizes_path: '/nl/umw_job_dekker/cshare/reference/sorted_chromsizes/T2T.chrom.sizes'
  


### PR DESCRIPTION
Added new references.
Now T2T can be used as option in distiller mapping