### PR TITLE
Model changes and options adding

### DIFF
--- a/cLIMS/organization/forms.py
+++ b/cLIMS/organization/forms.py
@@ -57,7 +57,7 @@ class ExperimentForm(ModelForm):
     class Meta:
         model = Experiment
         exclude = ('project','experiment_biosample','experiment_fields','dcic_alias','update_dcic','finalize_dcic_submission',)
-        fields = ['experiment_name','biocore_name','bio_rep_no','tec_rep_no','biosample_quantity','biosample_quantity_units','protocol','type','variation','experiment_enzyme',
+        fields = ['experiment_name','biocore_name','bio_rep_no','tec_rep_no','biosample_quantity','biosample_quantity_units','collection_method','protocol','type','variation','experiment_enzyme',
                   'antibody','authentication_docs','imageObjects','references','document','contributing_labs','url','dbxrefs','experiment_description']
          
        

--- a/cLIMS/organization/models.py
+++ b/cLIMS/organization/models.py
@@ -55,6 +55,14 @@ class Experiment(References):
         ('μg', 'μg'),
         ('ml', 'ml'),
         ('cells', 'cells'),
+        ('nuclei', 'nuclei'),
+    )
+    COLLECTION_CHOICES = (
+        ('', ''),
+        ('Trypsin', 'Trypsin'),
+        ('Scarpe', 'Scrape'),
+        ('Shake Off', 'Shake Off'),
+        ('Spin Down', 'Spin Down'),
     )
     experiment_name = models.CharField(max_length=300, null=False, unique=True, default="", db_index=True, validators=[alphanumeric])
     project = models.ForeignKey(Project,related_name='expProject', on_delete=models.CASCADE,)
@@ -83,6 +91,7 @@ class Experiment(References):
     update_dcic = models.BooleanField(default=False, help_text="This object needs to be updated at DCIC.")
     finalize_dcic_submission = models.BooleanField(default=False, help_text="This object and related entries have been submitted to DCIC")
     contributing_labs = models.ManyToManyField(ContributingLabs, blank=True, help_text="Contributing labs for this experiment.")
+    collection_method = models.CharField(max_length=20, choices=COLLECTION_CHOICES, default="",null=True, blank=True)
     created_at = models.DateTimeField(auto_now_add=True)
     
     def __str__(self):

--- a/cLIMS/organization/templates/detailExperiment.html
+++ b/cLIMS/organization/templates/detailExperiment.html
@@ -47,6 +47,7 @@
 <span class="rowHead">Biosample: </span>{{ experiment.experiment_biosample }}<br/>
 <span class="rowHead">Biosample Quantity: </span>{{ experiment.biosample_quantity }}<br/>
 <span class="rowHead">Biosample Quantity Units: </span>{{ experiment.biosample_quantity_units }}<br/>
+<span class="rowHead">Collection Method: </span>{{ experiment.collection_method }}<br/>
 <span class="rowHead">Protocol: </span><a href="/detailProtocol/{{ experiment.project.id }}/{{ experiment.id }}/{{ experiment.protocol.id }}">{{ experiment.protocol }}</a><br/>
 <span class="rowHead">Protocol Variations: </span><br/>
 {% if not experiment.variation  == None %}

--- a/cLIMS/organization/templates/exportDistillerForm.html
+++ b/cLIMS/organization/templates/exportDistillerForm.html
@@ -31,6 +31,8 @@
   <option value="galGal5">galGal5</option>
   <option value="smic1.0">smic1.0</option>
   <option value="sacCer3">sacCer3</option>
+  <option value="DT40">DT40</option>
+  <option value="T2T">T2T</option>
 </select>
 <hr>
 <h5>**Only selected experiments will be exported.</h5>

--- a/cLIMS/tools/distillerTools/sample_genomes.yaml
+++ b/cLIMS/tools/distillerTools/sample_genomes.yaml
@@ -22,4 +22,10 @@ smic1.0:
 sacCer3:
   bwa_index_wildcard_path: '/nl/umw_job_dekker/cshare/reference/bwa/sacCer3/sacCer3.*'
   chrom_sizes_path: '/nl/umw_job_dekker/cshare/reference/sorted_chromsizes/sacCer3.reduced.chrom.sizes'
+DT40:
+  bwa_index_wildcard_path: '/nl/umw_job_dekker/cshare/reference/bwa/DT40/DT40.*'
+  chrom_sizes_path: '/nl/umw_job_dekker/cshare/reference/sorted_chromsizes/DT40.reduced.chrom.sizes'
+T2T:
+  bwa_index_wildcard_path: '/nl/umw_job_dekker/cshare/reference/bwa/T2T/T2T.*'
+  chrom_sizes_path: '/nl/umw_job_dekker/cshare/reference/sorted_chromsizes/T2T.chrom.sizes'
  

--- a/cLIMS/tools/distillerTools/sample_genomes.yaml
+++ b/cLIMS/tools/distillerTools/sample_genomes.yaml
@@ -1,31 +1,31 @@
 hg38:
-  bwa_index_wildcard_path: '/nl/umw_job_dekker/cshare/reference/bwa/hg38/hg38*'
-  chrom_sizes_path: '/nl/umw_job_dekker/cshare/reference/sorted_chromsizes/hg38.reduced.chrom.sizes'
+  bwa_index_wildcard_path: '/pi/job.dekker-umw/common/reference/bwa/hg38/hg38*'
+  chrom_sizes_path: '/pi/job.dekker-umw/common/reference/sorted_chromsizes/hg38.reduced.chrom.sizes'
 hg19:
-  bwa_index_wildcard_path: '/nl/umw_job_dekker/cshare/reference/bwa/hg19/hg19.fa*'
-  chrom_sizes_path: '/nl/umw_job_dekker/cshare/reference/sorted_chromsizes/hg19.reduced.chrom.sizes'
+  bwa_index_wildcard_path: '/pi/job.dekker-umw/common/reference/bwa/hg19/hg19.fa*'
+  chrom_sizes_path: '/pi/job.dekker-umw/common/reference/sorted_chromsizes/hg19.reduced.chrom.sizes'
 mm10:
-  bwa_index_wildcard_path: '/nl/umw_job_dekker/cshare/reference/bwa/mm10/mm10*'
-  chrom_sizes_path: '/nl/umw_job_dekker/cshare/reference/sorted_chromsizes/mm10.reduced.chrom.sizes'
+  bwa_index_wildcard_path: '/pi/job.dekker-umw/common/reference/bwa/mm10/mm10*'
+  chrom_sizes_path: '/pi/job.dekker-umw/common/reference/sorted_chromsizes/mm10.reduced.chrom.sizes'
 mm9:
-  bwa_index_wildcard_path: '/nl/umw_job_dekker/cshare/reference/bwa/mm9/mm9*'
-  chrom_sizes_path: '/nl/umw_job_dekker/cshare/reference/sorted_chromsizes/mm9.reduced.chrom.sizes'
+  bwa_index_wildcard_path: '/pi/job.dekker-umw/common/reference/bwa/mm9/mm9*'
+  chrom_sizes_path: '/pi/job.dekker-umw/common/reference/sorted_chromsizes/mm9.reduced.chrom.sizes'
 galGal6:
-  bwa_index_wildcard_path: '/nl/umw_job_dekker/cshare/reference/bwa/galGal6/galGal6.fa*'
-  chrom_sizes_path: '/nl/umw_job_dekker/cshare/reference/sorted_chromsizes/galGal6.reduced.chrom.sizes'
+  bwa_index_wildcard_path: '/pi/job.dekker-umw/common/reference/bwa/galGal6/galGal6.fa*'
+  chrom_sizes_path: '/pi/job.dekker-umw/common/reference/sorted_chromsizes/galGal6.reduced.chrom.sizes'
 galGal5:
-  bwa_index_wildcard_path: '/nl/umw_job_dekker/cshare/reference/bwa/galGal5/galGal5.fa*'
-  chrom_sizes_path: '/nl/umw_job_dekker/cshare/reference/sorted_chromsizes/galGal5.reduced.chrom.sizes'
+  bwa_index_wildcard_path: '/pi/job.dekker-umw/common/reference/bwa/galGal5/galGal5.fa*'
+  chrom_sizes_path: '/pi/job.dekker-umw/common/reference/sorted_chromsizes/galGal5.reduced.chrom.sizes'
 smic1.0:
-  bwa_index_wildcard_path: '/nl/umw_job_dekker/users/an27w/dinoflagellets/genome/smic1.0/smic1.0.fa*'
-  chrom_sizes_path: '/nl/umw_job_dekker/users/an27w/dinoflagellets/genome/smic1.0/smic1.0.chrom.sizes'
+  bwa_index_wildcard_path: '/pi/job.dekker-umw/common/reference/bwa/smic1.0/smic1.0*'
+  chrom_sizes_path: '/pi/job.dekker-umw/common/reference/sorted_chromsizes/smic1.0.chrom.sizes'
 sacCer3:
-  bwa_index_wildcard_path: '/nl/umw_job_dekker/cshare/reference/bwa/sacCer3/sacCer3.*'
-  chrom_sizes_path: '/nl/umw_job_dekker/cshare/reference/sorted_chromsizes/sacCer3.reduced.chrom.sizes'
+  bwa_index_wildcard_path: '/pi/job.dekker-umw/common/reference/bwa/sacCer3/sacCer3.*'
+  chrom_sizes_path: '/pi/job.dekker-umw/common/reference/sorted_chromsizes/sacCer3.reduced.chrom.sizes'
 DT40:
-  bwa_index_wildcard_path: '/nl/umw_job_dekker/cshare/reference/bwa/DT40/DT40.*'
-  chrom_sizes_path: '/nl/umw_job_dekker/cshare/reference/sorted_chromsizes/DT40.reduced.chrom.sizes'
+  bwa_index_wildcard_path: '/pi/job.dekker-umw/common/reference/bwa/DT40/DT40.*'
+  chrom_sizes_path: '/pi/job.dekker-umw/common/reference/sorted_chromsizes/DT40.reduced.chrom.sizes'
 T2T:
-  bwa_index_wildcard_path: '/nl/umw_job_dekker/cshare/reference/bwa/T2T/T2T.*'
-  chrom_sizes_path: '/nl/umw_job_dekker/cshare/reference/sorted_chromsizes/T2T.chrom.sizes'
+  bwa_index_wildcard_path: '/pi/job.dekker-umw/common/reference/bwa/T2T/T2T.*'
+  chrom_sizes_path: '/pi/job.dekker-umw/common/reference/sorted_chromsizes/T2T.chrom.sizes'
  


### PR DESCRIPTION
From this commit onwards, the structure of the model changes.
So if old database dumps are used, the code of cLIMS will throw an error. So it is always better to use dumps which are like 2-3 days old
